### PR TITLE
Add Google DNS to the example config

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -31,3 +31,19 @@ upstream:
       read_timeout: 5s
       write_timeout: 5s
       stale_timeout: 10s
+    - addr: 8.8.8.8:853
+      server_name: dns.google
+      connection_pool_size: 8
+      connect_timeout: 100ms
+      handshake_timeout: 250ms
+      read_timeout: 5s
+      write_timeout: 5s
+      stale_timeout: 10s
+    - addr: 8.8.4.4:853
+      server_name: dns.google
+      connection_pool_size: 8
+      connect_timeout: 100ms
+      handshake_timeout: 250ms
+      read_timeout: 5s
+      write_timeout: 5s
+      stale_timeout: 10s


### PR DESCRIPTION
I thought it might be good to include a second provider in the example config to increase the likelihood finding a performance provider around the world.